### PR TITLE
Make Servme::Responder#process_json_request safer

### DIFF
--- a/lib/servme/responder.rb
+++ b/lib/servme/responder.rb
@@ -65,7 +65,8 @@ module Servme
   private
 
     def process_json_request(request)
-      if request.params && request.params.empty? && request.env && request.env['CONTENT_TYPE'] =~ /application\/json/
+      request_params = request.params rescue nil
+      if request_params && request_params.empty? && request.env && request.env['CONTENT_TYPE'] =~ /application\/json/
         parsed_json = JSON.parse(request.body.read)
         parsed_json.each do |k,v|
           request.params[k] = v


### PR DESCRIPTION
Guards against the off chance that the `Sinatra::Request` instance has no `params` attribute.

Considered doing the same thing for `env`, but from what I can tell, it is not possible to instantiate a `Sinatra::Request` without an `env` param.
