### PR TITLE
Allow arbitrary keys in header

### DIFF
--- a/lib/servme/stubber.rb
+++ b/lib/servme/stubber.rb
@@ -16,11 +16,23 @@ module Servme
         (urls[config[:method] || :get] ||= {}).tap do |methods|
           methods[stringify_keys(config[:params] || {})] = {
             :data => config[:response],
-            :headers => Responder::DEFAULT_HEADERS.merge(config[:headers] || {}),
+            :headers => get_headers(config),
             :status_code => config[:status_code] || 200
           }
         end
       end
+    end
+
+    def get_headers(config)
+      response = config[:response]
+
+      headers = if response.is_a?(Hash)
+        response.delete(:headers)
+      end || {}
+
+      headers.merge!(config[:headers] || {})
+
+      Responder::DEFAULT_HEADERS.merge(headers)
     end
 
     def stub_for_request(req)

--- a/spec/lib/servme/service_stubbing_spec.rb
+++ b/spec/lib/servme/service_stubbing_spec.rb
@@ -111,5 +111,18 @@ module Servme
       Then { last_response.headers['Content-Type'].should == "application/html" }
     end
 
+    describe "passing in another header option" do
+      Given do
+        ServiceStubbing.new({
+          :url => "/index",
+          :method => :get,
+        }).respond_with({:body => 'check out my body!', :headers => {'set-cookie' => 'logged_in=true'}})
+      end
+      When { get('/index') }
+      Then { last_response.body.should be_json :body => "check out my body!" }
+      Then { last_response.headers['set-cookie'].should == 'logged_in=true' }
+
+    end
+
   end
 end


### PR DESCRIPTION
Need the ability to pass in other keys, such as `set-cookie` to the header. 
