### PR TITLE
Don't use Set-Cookie header for tests

### DIFF
--- a/spec/lib/servme/service_stubbing_spec.rb
+++ b/spec/lib/servme/service_stubbing_spec.rb
@@ -116,11 +116,11 @@ module Servme
         ServiceStubbing.new({
           :url => "/index",
           :method => :get,
-        }).respond_with({:body => 'check out my body!', :headers => {'set-cookie' => 'logged_in=true'}})
+        }).respond_with({:body => 'check out my body!', :headers => {'some-header' => 'logged_in=true'}})
       end
       When { get('/index') }
       Then { last_response.body.should be_json :body => "check out my body!" }
-      Then { last_response.headers['set-cookie'].should == 'logged_in=true' }
+      Then { last_response.headers['some-header'].should == 'logged_in=true' }
 
     end
 


### PR DESCRIPTION
Because it doesn't work anymore.

I kicked off a build in Travis to see if it would still pass, and it [did not](https://travis-ci.org/github/testdouble/servme/builds/16900971). These changes make it pass again.